### PR TITLE
Debug test: force 100% probability for full Lead-to-Cash flow coverage

### DIFF
--- a/src/test/java/com/fedd/salesforce/plans/LeadToCashTestPlan.java
+++ b/src/test/java/com/fedd/salesforce/plans/LeadToCashTestPlan.java
@@ -77,9 +77,9 @@ public class LeadToCashTestPlan {
                                         "p_amount"),
                         httpCache().disable(),
                         httpCookies().disable(),
-                        // No think time, no InfluxDB
+                        // No think time, no InfluxDB, all steps forced to 100%
                         authGroup.getSetupThreadGroup(),
-                        leadToCashGroup.getLeadToCashThreadGroup(1, 1, false),
+                        leadToCashGroup.getLeadToCashThreadGroup(1, 1, false, true),
                         cleanUpGroup.getTeardownThreadGroup()
                 );
     }

--- a/src/test/java/com/fedd/salesforce/scenarios/LeadToCashThreadGroup.java
+++ b/src/test/java/com/fedd/salesforce/scenarios/LeadToCashThreadGroup.java
@@ -56,20 +56,41 @@ public class LeadToCashThreadGroup {
      * @param withThinkTime if {@code false}, skips the 4-6s random timer (useful for debug runs)
      */
     public DslDefaultThreadGroup getLeadToCashThreadGroup(int users, int iterations, boolean withThinkTime) {
+        return getLeadToCashThreadGroup(users, iterations, withThinkTime, false);
+    }
+
+    /**
+     * Builds the thread group with full control over think time and step execution.
+     *
+     * @param users         number of concurrent users
+     * @param iterations    iterations per user
+     * @param withThinkTime if {@code false}, skips the 4-6s random timer
+     * @param forceAllSteps if {@code true}, sets all probabilities to 100% so every
+     *                      branch executes (useful for debug/validation runs)
+     */
+    public DslDefaultThreadGroup getLeadToCashThreadGroup(int users, int iterations,
+            boolean withThinkTime, boolean forceAllSteps) {
+
+        String noteChance     = forceAllSteps ? "100" : NOTE_CHANCE;
+        String taskChance     = forceAllSteps ? "100" : TASK_CHANCE;
+        String eventChance    = forceAllSteps ? "100" : EVENT_CHANCE;
+        String caseChance     = forceAllSteps ? "100" : CASE_CHANCE;
+        String conversionRate = forceAllSteps ? "100" : CONVERSION_RATE;
+        String closingRate    = forceAllSteps ? "100" : CLOSING_RATE;
 
         DslDefaultThreadGroup tg = threadGroup("Lead to Cash", users, iterations,
 
                 httpHeaders()
                         .header("Authorization", "Bearer ${__P(ACCESS_TOKEN,)}"),
 
-                // Load percentages into JMeter variables correctly
+                // Load percentages into JMeter variables
                 vars()
-                        .set("NOTE_CHANCE", NOTE_CHANCE)
-                        .set("TASK_CHANCE", TASK_CHANCE)
-                        .set("EVENT_CHANCE", EVENT_CHANCE)
-                        .set("CASE_CHANCE", CASE_CHANCE)
-                        .set("LEAD_CONVERSION_RATE", CONVERSION_RATE)
-                        .set("CLOSING_RATE", CLOSING_RATE));
+                        .set("NOTE_CHANCE", noteChance)
+                        .set("TASK_CHANCE", taskChance)
+                        .set("EVENT_CHANCE", eventChance)
+                        .set("CASE_CHANCE", caseChance)
+                        .set("LEAD_CONVERSION_RATE", conversionRate)
+                        .set("CLOSING_RATE", closingRate));
 
         if (withThinkTime) {
             // Random think time between 4-6 seconds


### PR DESCRIPTION
Closes #33

## Summary

The debug test (`mvn test -Pdebug`) now exercises the **full Lead-to-Cash pipeline** — all 21 samplers execute with 0 errors.

### Changes

- Added `forceAllSteps` parameter to `LeadToCashThreadGroup.getLeadToCashThreadGroup()`
- When `true`, overrides all `ifController` probabilities to 100%:
  - `NOTE_CHANCE`, `TASK_CHANCE`, `EVENT_CHANCE`, `CASE_CHANCE` → 100
  - `CONVERSION_RATE`, `CLOSING_RATE` → 100
- Updated `getDebugTestPlan()` to pass `forceAllSteps=true`

### Validated Flow

| # | Sampler | HTTP | Status |
|---|---------|------|--------|
| 1 | Authentication | 200 | PASS |
| 2 | CREATE New Lead | 201 | PASS |
| 3 | CREATE New Note | 201 | PASS |
| 4 | CREATE New Task | 201 | PASS |
| 5 | CREATE New Event | 201 | PASS |
| 6 | CREATE New Case | 201 | PASS |
| 7 | UPDATE Lead to Close - Converted (SOAP) | 200 | PASS |
| 8 | UPDATE Opportunity to Closed Won | 204 | PASS |
| 9-21 | Cleanup (GET + DELETE all objects) | 200/204 | PASS |